### PR TITLE
Pin MySQL to 5.6.40

### DIFF
--- a/mysql/Dockerfile
+++ b/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql
+FROM mysql:5.6
 
 COPY docker-healthcheck /usr/local/bin/
 


### PR DESCRIPTION
The latest MySQL image is 8.0+ and we're on 5.6 in production.