### PR TITLE
Improve RabbitMQ HEALTHCHECK

### DIFF
--- a/rabbitmq/docker-healthcheck
+++ b/rabbitmq/docker-healthcheck
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -eo pipefail
 
-host="$(hostname -s || echo 'localhost')"
-export RABBITMQ_NODENAME="${RABBITMQ_NODENAME:-"rabbit@$host"}"
+# A RabbitMQ node is considered healthy if all the below are true:
+# * the rabbit app finished booting & it's running
+# * there are no alarms
+# * there is at least 1 active listener
 
-if rabbitmqctl status; then
-	exit 0
-fi
-
-exit 1
+rabbitmqctl eval '
+{ true, rabbit_app_booted_and_running } = { rabbit:is_booted(node()), rabbit_app_booted_and_running },
+{ [], no_alarms } = { rabbit:alarms(), no_alarms },
+[] /= rabbit_networking:active_listeners(),
+rabbitmq_node_is_healthy.
+' || exit 1


### PR DESCRIPTION
This improves on rabbitmqctl status by making specific assertions about
alarms & active listeners. When assertions fail, the errors will be
(relatively) easy to understand, e.g.

    {{:badmatch, {true, :rabbit_app_booted_and_is_running}}, [{:erl_eval, :expr, 5, [file: 'erl_eval.erl', line: 453]}, {:erl_eval, :exprs, 5, [file: 'erl_eval.erl', line: 126]}, {:rpc, :"-handle_call_call/6-fun-0-", 5, [file: 'rpc.erl', line: 197]}]}

This is a follow-up from docker-library/rabbitmq#300