### PR TITLE
Dockerfile.mariadb - use included healthcheck

### DIFF
--- a/mysql/Dockerfile.mariadb
+++ b/mysql/Dockerfile.mariadb
@@ -2,4 +2,4 @@ FROM mariadb
 
 ENV MARIADB_MYSQL_LOCALHOST_USER=1
 
-HEALTHCHECK CMD ["/usr/local/bin/healthcheck.sh", "--su=mysql", "--innodb_initialized"]
+HEALTHCHECK CMD ["/usr/local/bin/healthcheck.sh", "--su=mysql", "--connect", "--innodb_initialized"]

--- a/mysql/Dockerfile.mariadb
+++ b/mysql/Dockerfile.mariadb
@@ -2,4 +2,4 @@ FROM mariadb
 
 ENV MARIADB_MYSQL_LOCALHOST_USER=1
 
-HEALTHCHECK CMD ["/usr/local/bin/healthcheck.sh", "--su=mysql", "--connect", "--innodb_initialized"]
+HEALTHCHECK CMD ["healthcheck.sh", "--su=mysql", "--connect", "--innodb_initialized"]

--- a/mysql/Dockerfile.mariadb
+++ b/mysql/Dockerfile.mariadb
@@ -1,5 +1,5 @@
 FROM mariadb
 
-COPY docker-healthcheck /usr/local/bin/
+ENV MARIADB_MYSQL_LOCALHOST_USER=1
 
-HEALTHCHECK CMD ["docker-healthcheck"]
+HEALTHCHECK CMD ["/usr/local/bin/healthcheck.sh", "--su=mysql", "--innodb_initialized"]


### PR DESCRIPTION
MARIADB_MYSQL_LOCALHOST_USER=1 creates the mysql@localhost user that the healthcheck uses with --su=mysql.

`--innodb_initialized` was chosen as a fairly basic test to ensure that any crash recovery is complete.