### PR TITLE
Update docker-healthcheck for mongodb 6.0+

### DIFF
--- a/mongo/Dockerfile.4.4
+++ b/mongo/Dockerfile.4.4
@@ -1,4 +1,4 @@
-FROM mongo
+FROM mongo:4.4
 
 COPY docker-healthcheck /usr/local/bin/
 

--- a/mongo/Dockerfile.5.0
+++ b/mongo/Dockerfile.5.0
@@ -1,0 +1,5 @@
+FROM mongo:5.0
+
+COPY docker-healthcheck /usr/local/bin/
+
+HEALTHCHECK CMD ["docker-healthcheck"]

--- a/mongo/Dockerfile.latest
+++ b/mongo/Dockerfile.latest
@@ -1,0 +1,5 @@
+FROM mongo:latest
+
+COPY docker-healthcheck /usr/local/bin/
+
+HEALTHCHECK CMD ["docker-healthcheck"]

--- a/mongo/docker-healthcheck
+++ b/mongo/docker-healthcheck
@@ -3,7 +3,13 @@ set -eo pipefail
 
 host="$(hostname --ip-address || echo '127.0.0.1')"
 
-if mongo --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
+# version < 6.0.0
+# if mongo --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
+#	exit 0
+# fi
+
+# version > 6.0.0
+if mongosh --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
 	exit 0
 fi
 

--- a/mongo/docker-healthcheck
+++ b/mongo/docker-healthcheck
@@ -3,14 +3,17 @@ set -eo pipefail
 
 host="$(hostname --ip-address || echo '127.0.0.1')"
 
-# version < 6.0.0
-# if mongo --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
-#	exit 0
-# fi
+# mongo for version <= 4.4
+# mongosh for version >= 5.0
+for cmd in mongosh mongo; do
+	if ! command -v "$cmd" > /dev/null; then
+		continue;
+	fi
 
-# version > 6.0.0
-if mongosh --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
-	exit 0
-fi
+	if "$cmd" --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
+		exit 0
+	fi
+
+done
 
 exit 1


### PR DESCRIPTION
Due an upgrade of mongodb version 6.0.0+ The `mongo` command was changed to `mongosh` command.