### PR TITLE
mongosh command instead of mongo

### DIFF
--- a/mongo/docker-healthcheck
+++ b/mongo/docker-healthcheck
@@ -3,7 +3,7 @@ set -eo pipefail
 
 host="$(hostname --ip-address || echo '127.0.0.1')"
 
-if mongo --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
+if mongosh --quiet "$host/test" --eval 'quit(db.runCommand({ ping: 1 }).ok ? 0 : 2)'; then
 	exit 0
 fi
 


### PR DESCRIPTION
`mongo` command is deprecated as of MongoDB v5.0, and it is replaced with `mongosh`; see [Deprecations - Compatibility Changes in MongoDB 5.0 - MongoDB Manual v7.0](https://www.mongodb.com/docs/manual/release-notes/5.0-compatibility/#deprecations). The `mongo` command is not available in the current latest version (7.0.11).